### PR TITLE
Switch Mollie env call to config file for caching

### DIFF
--- a/app/Helpers/Payment/MolliePaymentProvider.php
+++ b/app/Helpers/Payment/MolliePaymentProvider.php
@@ -13,7 +13,7 @@ class MolliePaymentProvider implements PaymentProvider
     public function __construct()
     {
         $this->mollie = new \Mollie\Api\MollieApiClient();
-        $this->mollie->setApiKey(env('MOLLIE_API_KEY'));
+        $this->mollie->setApiKey(config('mollie.api_key'));
     }
 
     public function api()

--- a/config/mollie.php
+++ b/config/mollie.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    'api_key' => env('MOLLIE_API_KEY', test_3RAxAtCZAZh5pZAjUcf6U89WH6DNVr)
+    'api_key' => env('MOLLIE_API_KEY', 'test_3RAxAtCZAZh5pZAjUcf6U89WH6DNVr')
 ];

--- a/config/mollie.php
+++ b/config/mollie.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'api_key' => env('MOLLIE_API_KEY', test_3RAxAtCZAZh5pZAjUcf6U89WH6DNVr)
+];


### PR DESCRIPTION
@blackshadev iDeal heeft in de live omgeving niet meer goed gewerkt sinds het doorvoeren van de Mollie upgrade. Probleem zat in het cachen van de config, er staat wat meer over in de docs:

https://laravel.com/docs/5.8/configuration#configuration-caching

Ik ga niet wachten op je review, als de Travis build slaagt dan voer ik 'm door en ga ik live opnieuw testen. Dit is meer als heads up voor een volgende keer :)