### PR TITLE
Updated to Carbon 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,12 @@
   "require": {
     "laravel/framework": "5.8.*",
     "laravelcollective/html": "~5.0",
+    "nesbot/carbon": "^2.0",
     "barryvdh/laravel-dompdf": "0.8.*",
     "maatwebsite/excel": "~3.1.0",
     "mollie/mollie-api-php": "^2.0",
     "intervention/image": "^2.3",
-    "khill/lavacharts": "3.0.*",
+    "khill/lavacharts": "^3.1",
     "caouecs/laravel-lang": "~3.0",
     "fideloper/proxy": "^4.1",
     "graham-campbell/markdown": "^11.0"


### PR DESCRIPTION
Closes #37 

De maintainer van lavacharts heeft eindelijk zijn release uitgebracht en we kunnen dus naar Carbon 2. Zijn we van dat deprecation gezeik af. Ik heb een grove check gedaan en er lijkt niets stuk te gaan, en de unit tests staan op groen, dus...