### PR TITLE
Betere lijst van ervaren trainers

### DIFF
--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -152,7 +152,8 @@ class PagesController extends Controller
 		$ranonkeltjeDigitaal = \App\Member::whereIn('ranonkeltje', ['digitaal', 'beide'])->orderBy('voornaam', 'asc')->get();
 
 		// Ervaren trainers
-		$trainerList = \App\Member::where('ervaren_trainer', 1)->orderBy('voornaam', 'asc')->get();
+		$trainerList = \App\Member::where('ervaren_trainer', 1)->where('soort', '<>', 'oud')->orderBy('voornaam', 'asc')->get();
+		$oldTrainerList = \App\Member::where('ervaren_trainer', 1)->where('soort', 'oud')->orderBy('voornaam', 'asc')->get();
 
 		// Niet betaalde deelnemers
 		$unpaidList = \DB::table('event_participant')
@@ -222,7 +223,23 @@ class PagesController extends Controller
 		$startDate = Carbon::now()->subYears(19);
 		$participantMailingList = \App\Participant::where('mag_gemaild', 1)->where('geboortedatum', '>', $startDate->toDateString())->get();
 
-		return view('pages.lists', compact('stats', 'types', 'ranonkeltjePapier', 'ranonkeltjeDigitaal', 'trainerList', 'unpaidList', 'kmgList', 'aspirantList', 'birthdayList', 'courses', 'monthName', 'membersWithoutEvents', 'participantsWithoutCamps', 'participantMailingList'));
+		return view('pages.lists', compact(
+			'stats',
+			'types',
+			'ranonkeltjePapier',
+			'ranonkeltjeDigitaal',
+			'trainerList',
+			'oldTrainerList',
+			'unpaidList',
+			'kmgList',
+			'aspirantList',
+			'birthdayList',
+			'courses',
+			'monthName',
+			'membersWithoutEvents',
+			'participantsWithoutCamps',
+			'participantMailingList'
+		));
 	}
 
 	# Analytical graphs

--- a/database/seeds/MemberTableSeeder.php
+++ b/database/seeds/MemberTableSeeder.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Seeder;
 use Illuminate\Database\Eloquent\Model;
 use App\Member;
 
-class MemberTableSeeder extends Seeder {
+class MemberTableSeeder extends Seeder
+{
 
 	/**
 	 * Run the database seeds.
@@ -14,7 +15,7 @@ class MemberTableSeeder extends Seeder {
 	public function run()
 	{
 		DB::table('members')->delete();
-		
+
 		Member::create([
 			'voornaam' => 'Ranonkeltje',
 			'tussenvoegsel' => 'van',
@@ -42,7 +43,7 @@ class MemberTableSeeder extends Seeder {
 			'opmerkingen' => 'Ik ben het allergaafste spookje ooit! En ook nog eens heel bescheiden.',
 			'opmerkingen_admin' => 'Wauw wat is zij tof inderdaad.'
 		]);
-		
+
 		Member::create([
 			'voornaam' => 'Jön',
 			'achternaam' => 'Snow',
@@ -66,7 +67,7 @@ class MemberTableSeeder extends Seeder {
 			'opmerkingen' => 'Winter is coming.',
 			'opmerkingen_admin' => 'Hij weet echt niks.'
 		]);
-		
+
 		Member::create([
 			'voornaam' => 'Dingo',
 			'achternaam' => 'Krijgsman',
@@ -90,6 +91,30 @@ class MemberTableSeeder extends Seeder {
 			'opmerkingen' => 'YEEHAW!',
 			'opmerkingen_admin' => 'Licht autistisch en een beetje gestoord.'
 		]);
-	}
 
+		Member::create([
+			'voornaam' => 'Bert',
+			'tussenvoegsel' => 'van der',
+			'achternaam' => 'Ven',
+			'geslacht' => 'M',
+			'geboortedatum' => '1950-03-16',
+			'adres' => 'Bejaardenstraat 17',
+			'postcode' => '8866 ZX',
+			'plaats' => 'Grandpatown',
+			'telefoon' => '0689726239',
+			'email' => 'b.vanderven@planetzz.nl',
+			'email_anderwijs' => '',
+			'soort' => 'oud',
+			'eindexamen' => 'HAVO',
+			'studie' => 'Geriatrie',
+			'afgestudeerd' => '1',
+			'hoebij' => 'De krant',
+			'kmg' => '1',
+			'ranonkeltje' => '0',
+			'vog' => '1',
+			'ervaren_trainer' => '1',
+			'opmerkingen' => 'Ik ben doof aan één kant en slechtziend aan de andere.',
+			'opmerkingen_admin' => 'Serieus, waar is deze vent vandaan gekomen?'
+		]);
+	}
 }

--- a/resources/views/pages/lists.blade.php
+++ b/resources/views/pages/lists.blade.php
@@ -244,29 +244,56 @@
 	</div>
 	
 	<div role="tabpanel" class="tab-pane" id="trainers">
-		<h3>Ervaren trainers</h3>
+
+		<p>Geeft iemand aan niet meer te willen trainen? Haal dan het vinkje 'ervaren trainer' bij die persoon weg.</p>
+
+		<h3>Ervaren trainers (huidige leden)</h3>
 		<table class="table table-hover">
 			<thead>
 				<tr>
 					<th>Naam</th>
 					<th>Telefoon</th>
-					<th>Email persoonlijk</th>
 					<th>Email Anderwijs</th>
 					<th>Soort lid</th>
 				</tr>
 			</thead>
 			<tbody>
-				@foreach ($trainerList as $member)
+				@foreach ($trainerList as $m)
 					<tr>
-						<td><a href="{{ url('/members', $member->id) }}">{{ $member->voornaam }} {{ $member->tussenvoegsel }} {{ $member->achternaam }}</a></td>
-						<td>{{ $member->telefoon }}</td>
-						<td><a href="mailto:{{$member->email}}">{{ $member->email }}</a></td>
-						<td><a href="mailto:{{$member->email_anderwijs}}">{{ $member->email_anderwijs }}</a></td>
-						<td>{{ $member->soort }}</td>
+						<td><a href="{{ url('/members', $m->id) }}">{{ $m->volnaam }}</a></td>
+						<td>{{ $m->telefoon }}</td>
+						<td><a href="mailto:{{$m->email_anderwijs}}">{{ $m->email_anderwijs }}</a></td>
+						<td>{{ $m->soort }}</td>
 					</tr>
 				@endforeach
 			</tbody>
 		</table>
+
+		<h4>Mailinglijst</h4>
+		<p>{{ implode(', ', $trainerList->pluck('email_anderwijs')->toArray()) }}</p>
+
+		<h3>Ervaren trainers (oud-leden)</h3>
+		<table class="table table-hover">
+			<thead>
+				<tr>
+					<th>Naam</th>
+					<th>Telefoon</th>
+					<th>Email</th>
+				</tr>
+			</thead>
+			<tbody>
+				@foreach ($oldTrainerList as $m)
+					<tr>
+						<td><a href="{{ url('/members', $m->id) }}">{{ $m->volnaam }}</a></td>
+						<td>{{ $m->telefoon }}</td>
+						<td><a href="mailto:{{$m->email}}">{{ $m->email }}</a></td>
+					</tr>
+				@endforeach
+			</tbody>
+		</table>
+
+		<h4>Mailinglijst <small>(denk aan de BCC!)</small></h4>
+		<p>{{ implode(', ', $oldTrainerList->pluck('email')->toArray()) }}</p>
 	</div>
 	
 	<div role="tabpanel" class="tab-pane" id="verjaardag">


### PR DESCRIPTION
Fixes #46 

Splitst de lijst van ervaren trainers op in huidige leden (aspirant/normaal/info) en oud-leden, voegt voor beiden emaillijsten toe, en ik heb een oud-lid toegevoegd aan de database seed om makkelijker visueel te kunnen controleren.