### PR TITLE
Fix: datatables voor member index

### DIFF
--- a/resources/views/members/index.blade.php
+++ b/resources/views/members/index.blade.php
@@ -52,12 +52,12 @@ Leden
 			<table class="table table-hover" id="currentMembersTable">
 				<thead>
 					<tr>
-						<th>Voornaam</th>
+						<th data-orderable="true">Voornaam</th>
 						<th></th>
-						<th>Achternaam</th>
-						<th>Woonplaats</th>
+						<th data-orderable="true">Achternaam</th>
+						<th data-orderable="true">Woonplaats</th>
 						@can("showPracticalAny", \App\Member::class)
-						<th>Soort lid</th>
+						<th data-orderable="true">Soort lid</th>
 						@endcan
 						@can("showAdministrativeAny", \App\Member::class)
 						<th>VOG</th>
@@ -111,14 +111,13 @@ Leden
 		@can("listOldMembers", \App\Member::class)
 		<div role="tabpanel" class="tab-pane" id="oud">
 			<!-- Tabel oud-leden -->
-			<table class="table table-hover" id="formerMembersTable" data-page-length="25">
+			<table class="table table-hover" id="oldMembersTable" data-page-length="25">
 				<thead>
 					<tr>
-						<th>Voornaam</th>
+						<th data-orderable="true">Voornaam</th>
 						<th></th>
-						<th>Achternaam</th>
-						<th>Woonplaats</th>
-						<!--<th>Soort lid</th>-->
+						<th data-orderable="true">Achternaam</th>
+						<th data-orderable="true">Woonplaats</th>
 						<th>Telefoon</th>
 						<th>Email</th>
 					</tr>
@@ -131,7 +130,6 @@ Leden
 						<td>{{ $member->tussenvoegsel }}</td>
 						<td>{{ $member->achternaam }}</td>
 						<td>{{ $member->plaats }}</td>
-						<!--<td>{{ $member->soort }}</td>-->
 						<td>{{ $member->telefoon }}</td>
 						<td><a href="mailto:{{ $member->email }}">{{ $member->email }}</a></td>
 					</tr>
@@ -148,34 +146,27 @@ Leden
 @section('footer')
 <!-- These scripts load DataTables -->
 <script type="text/javascript">
+	function getColumnOptions(tableHeaderSelector) {
+		let columnOptions = [];
+		$(tableHeaderSelector).each(function(i) {
+			let option = ($(this).data('orderable')) ? null : {'orderable': false};
+			columnOptions.push(option);
+		})
+		return columnOptions;
+	}
+	
 	$( document ).ready(function() {
 
-	// Create the column options for the members table (number of columns can vary with user capabilities)
-	let memberColumnCount = $('#currentMembersTable').find('tr:first th').length;
-	let orderableColumnIndices = [0, 2, 3];
-	let columnOptions = [];
-	for (let i = 0; i < memberColumnCount; i++) {
-		let option = (orderableColumnIndices.includes(i)) ? null : {'orderable': false};
-		columnOptions.push(option);
-	}
+		$('#currentMembersTable').DataTable({
+			paging: false,
+			order: [[ 0, "asc" ]],
+			columns: getColumnOptions('#currentMembersTable tr:first th')
+		});
 
-    $('#currentMembersTable').DataTable({
-		paging: false,
-		order: [[ 0, "asc" ]],
-		columns: columnOptions
+		$('#oldMembersTable').DataTable({
+			order: [[ 0, "asc" ]],
+			columns: getColumnOptions('#oldMembersTable tr:first th')
+		});
 	});
-
-	$('#formerMembersTable').DataTable({
-		order: [[ 0, "asc" ]],
-		columns: [
-			null,
-			{'orderable':false},
-			null,
-			null,
-			{'orderable':false},
-			{'orderable':false}
-		]
-	});
-});
 </script>
 @endsection

--- a/resources/views/members/index.blade.php
+++ b/resources/views/members/index.blade.php
@@ -1,7 +1,7 @@
 @extends('master')
 
 @section('title')
-	Leden
+Leden
 @endsection
 
 @section('content')
@@ -15,57 +15,62 @@
 	<div class="col-sm-6">
 		<p class="text-right">
 			@can("create", \App\Member::class)
-			<a class="btn btn-primary" type="button" href="{{ url('members/create') }}" style="margin-top:21px;">Nieuw lid</a>
+			<a class="btn btn-primary" type="button" href="{{ url('members/create') }}" style="margin-top:21px;">Nieuw
+				lid</a>
 			@endcan
 			@can("showPracticalAny", \App\Member::class)
-			<a class="btn btn-info" type="button" href="{{ url('members/search')}}" style="margin-top:21px;">Zoeken op vakdekking</a>
+			<a class="btn btn-info" type="button" href="{{ url('members/search')}}" style="margin-top:21px;">Zoeken op
+				vakdekking</a>
 			@endcan
 			@can("showAdministrativeAny", \App\Member::class)
-			{{-- <a class="btn btn-warning" type="button" href="{{ url('members/map') }}" style="margin-top:21px;">Kaart</a> --}}
-			<a class="btn btn-success" type="button" href="{{ url('members/export') }}" style="margin-top:21px;">Exporteren</a>
+			{{-- <a class="btn btn-warning" type="button" href="{{ url('members/map') }}"
+			style="margin-top:21px;">Kaart</a> --}}
+			<a class="btn btn-success" type="button" href="{{ url('members/export') }}"
+				style="margin-top:21px;">Exporteren</a>
 			@endcan
 		</p>
 	</div>
 </div>
 
-<hr/>
+<hr />
 
 <div role="tabpanel">
 
-  <!-- Nav tabs -->
-  <ul class="nav nav-tabs" role="tablist">
-    <li role="presentation" class="active"><a href="#huidig" aria-controls="huidig" role="tab" data-toggle="tab">Huidige leden</a></li>
-	@can("listOldMembers", \App\Member::class)
-	<li role="presentation"><a href="#oud" aria-controls="oud" role="tab" data-toggle="tab">Oud-leden</a></li>
-	@endcan
-</ul>
+	<!-- Nav tabs -->
+	<ul class="nav nav-tabs" role="tablist">
+		<li role="presentation" class="active"><a href="#huidig" aria-controls="huidig" role="tab"
+				data-toggle="tab">Huidige leden</a></li>
+		@can("listOldMembers", \App\Member::class)
+		<li role="presentation"><a href="#oud" aria-controls="oud" role="tab" data-toggle="tab">Oud-leden</a></li>
+		@endcan
+	</ul>
 
-  <!-- Tab panes -->
-  <div class="tab-content" style="margin-top:20px;">
-    <div role="tabpanel" class="tab-pane active" id="huidig">
-		<!-- Tabel huidige leden -->
-		<table class="table table-hover" id="currentMembersTable">
-			<thead>
-				<tr>
-					<th>Voornaam</th>
-					<th></th>
-					<th>Achternaam</th>
-					<th>Woonplaats</th>
-					@can("showPracticalAny", \App\Member::class)
-					<th>Soort lid</th>
-					@endcan
-					@can("showAdministrativeAny", \App\Member::class)
-					<th>VOG</th>
-					@endcan
-					@can("showPrivateAny", \App\Member::class)
-					<th>Telefoon</th>
-					@endcan
-					<th>Email</th>
-				</tr>
-			</thead>
-			
-			<tbody>
-				@foreach ($current_members as $member)
+	<!-- Tab panes -->
+	<div class="tab-content" style="margin-top:20px;">
+		<div role="tabpanel" class="tab-pane active" id="huidig">
+			<!-- Tabel huidige leden -->
+			<table class="table table-hover" id="currentMembersTable">
+				<thead>
+					<tr>
+						<th>Voornaam</th>
+						<th></th>
+						<th>Achternaam</th>
+						<th>Woonplaats</th>
+						@can("showPracticalAny", \App\Member::class)
+						<th>Soort lid</th>
+						@endcan
+						@can("showAdministrativeAny", \App\Member::class)
+						<th>VOG</th>
+						@endcan
+						@can("showPrivateAny", \App\Member::class)
+						<th>Telefoon</th>
+						@endcan
+						<th>Email</th>
+					</tr>
+				</thead>
+
+				<tbody>
+					@foreach ($current_members as $member)
 					<tr>
 						<td>
 							@can("view", $member)
@@ -78,18 +83,18 @@
 						<td>{{ $member->achternaam }}</td>
 						<td>{{ $member->plaats }}</td>
 
-						@can("showPracticalAny", \App\Member::class)						
+						@can("showPracticalAny", \App\Member::class)
 						<td>{{ $member->soort }}</td>
 						@endcan
 
 						@can("showAdministrativeAny", \App\Member::class)
 						<td>
 							@if ($member->vog)
-								<span style="display:none;">1</span>
-								<span class="glyphicon glyphicon-ok"></span>
+							<span style="display:none;">1</span>
+							<span class="glyphicon glyphicon-ok"></span>
 							@else
-								<span style="display:none;">0</span>	
-								<span class="glyphicon glyphicon-remove"></span>
+							<span style="display:none;">0</span>
+							<span class="glyphicon glyphicon-remove"></span>
 							@endif
 						</td>
 						@endcan
@@ -98,29 +103,29 @@
 						@endcan
 						<td><a href="mailto:{{ $member->email_anderwijs }}">{{ $member->email_anderwijs }}</a></td>
 					</tr>
-				@endforeach
-			</tbody>
-		</table>
-	</div>
-	
-	@can("listOldMembers", \App\Member::class)
-    <div role="tabpanel" class="tab-pane" id="oud">
-		<!-- Tabel oud-leden -->
-		<table class="table table-hover" id="formerMembersTable" data-page-length="25">
-			<thead>
-				<tr>
-					<th>Voornaam</th>
-					<th></th>
-					<th>Achternaam</th>
-					<th>Woonplaats</th>
-					<!--<th>Soort lid</th>-->
-					<th>Telefoon</th>
-					<th>Email</th>
-				</tr>
-			</thead>
-			
-			<tbody>
-				@foreach ($former_members as $member)
+					@endforeach
+				</tbody>
+			</table>
+		</div>
+
+		@can("listOldMembers", \App\Member::class)
+		<div role="tabpanel" class="tab-pane" id="oud">
+			<!-- Tabel oud-leden -->
+			<table class="table table-hover" id="formerMembersTable" data-page-length="25">
+				<thead>
+					<tr>
+						<th>Voornaam</th>
+						<th></th>
+						<th>Achternaam</th>
+						<th>Woonplaats</th>
+						<!--<th>Soort lid</th>-->
+						<th>Telefoon</th>
+						<th>Email</th>
+					</tr>
+				</thead>
+
+				<tbody>
+					@foreach ($former_members as $member)
 					<tr>
 						<td><a href="{{ url('/members', $member->id) }}">{{ $member->voornaam }}</a></td>
 						<td>{{ $member->tussenvoegsel }}</td>
@@ -130,12 +135,12 @@
 						<td>{{ $member->telefoon }}</td>
 						<td><a href="mailto:{{ $member->email }}">{{ $member->email }}</a></td>
 					</tr>
-				@endforeach
-			</tbody>
-		</table>
+					@endforeach
+				</tbody>
+			</table>
+		</div>
+		@endcan
 	</div>
-	@endcan
-  </div>
 
 </div>
 @endsection
@@ -143,22 +148,23 @@
 @section('footer')
 <!-- These scripts load DataTables -->
 <script type="text/javascript">
-$( document ).ready(function() {
+	$( document ).ready(function() {
+
+	// Create the column options for the members table (number of columns can vary with user capabilities)
+	let memberColumnCount = $('#currentMembersTable').find('tr:first th').length;
+	let orderableColumnIndices = [0, 2, 3];
+	let columnOptions = [];
+	for (let i = 0; i < memberColumnCount; i++) {
+		let option = (orderableColumnIndices.includes(i)) ? null : {'orderable': false};
+		columnOptions.push(option);
+	}
+
     $('#currentMembersTable').DataTable({
 		paging: false,
 		order: [[ 0, "asc" ]],
-		columns: [
-			null,
-			{'orderable':false},
-			null,
-			null,
-			null,
-			null,
-			{'orderable':false},
-			{'orderable':false}
-		]
+		columns: columnOptions
 	});
-	
+
 	$('#formerMembersTable').DataTable({
 		order: [[ 0, "asc" ]],
 		columns: [
@@ -166,7 +172,6 @@ $( document ).ready(function() {
 			{'orderable':false},
 			null,
 			null,
-			//null,
 			{'orderable':false},
 			{'orderable':false}
 		]


### PR DESCRIPTION
Closes #75 

Klein beetje javascript om te zorgen dat de DataTable definitie altijd goed gaat ongeacht het aantal kolommen in de `members.index`.

Het gaat om het stuk JS onderaan de file, de rest is auto layout van VScode.