### PR TITLE
fixed email template with regards to camp pricing

### DIFF
--- a/resources/views/emails/participants/onEventConfirmation.blade.php
+++ b/resources/views/emails/participants/onEventConfirmation.blade.php
@@ -31,7 +31,7 @@
 	U bevindt zich nu in de eerste stap van het plaatsingsproces van uw kind voor een Anderwijskamp. Voor meer informatie over het proces, dat bestaat uit vier stappen, klikt u <a href="http://www.anderwijs.nl/inschrijven/stappenplan">hier</a>.
 </p>
 
-@if ($event->prijs == 0)
+@if ($toPay == 0)
 	<p>
 		Uw kind staat op dit moment voorlopig ingeschreven voor het kamp. Om de inschrijving definitief te maken, dient u het kampgeld over te maken op onze rekening. <strong>Voor dit kamp is het kampgeld echter nog niet definitief vastgesteld.</strong> Zodra dat is gebeurd, ontvangt u daarover per e-mail bericht.
 	</p>

--- a/resources/views/registration/participantStored.blade.php
+++ b/resources/views/registration/participantStored.blade.php
@@ -10,7 +10,7 @@
 
 <hr/>
 
-@if ($camp->prijs == 0)
+@if ($toPay == 0)
 	<p>
 		U heeft uw kind succesvol ingeschreven voor een Anderwijskamp. Binnen enkele momenten ontvangt u een automatische bevestigingsmail op het door u opgegeven emailadres. Om de inschrijving definitief te maken, dient u het kampgeld over te maken op onze rekening. <strong>Voor dit kamp is het kampgeld echter nog niet definitief vastgesteld.</strong> Zodra dat is gebeurd, ontvangt u daarover per e-mail bericht.
 	</p>


### PR DESCRIPTION
Fixed issue reported by Liesbeth, The confirmation email used the wrong text because it still checked the $camp->prijs instead of the calculated price of $toPay