### PR TITLE
Fixed graph ordering and kamp selection

### DIFF
--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -322,7 +322,8 @@ class PagesController extends Controller
 					FROM events e 
 					LEFT JOIN event_participant ep on ep.event_id = e.id
 					LEFT JOIN event_member em on em.event_id = e.id
-					GROUP BY e.id
+				   WHERE e.type in ('kamp')
+					GROUP BY e.id DESC
 					LIMIT 10
 				) s
 				join events e on s.id = e.id


### PR DESCRIPTION
- Fixed avg registration days before camp ordering to get the LAST 10 instead of the FIRST 10
- Limited selection to camps only.