### PR TITLE
Hotfix/participant policy

### DIFF
--- a/app/Policies/ParticipantPolicy.php
+++ b/app/Policies/ParticipantPolicy.php
@@ -123,6 +123,11 @@ class ParticipantPolicy
         return $user->hasCapability("participants::info::show::administrative");
     }
 
+    public function showAdministrative(User $user, Participant $participant)
+    {
+        return $this->showAdministrativeAny($user);
+    }
+
     public function editFinanceAny(User $user)
     {
         return $user->hasCapability("participants::info::edit::finance");
@@ -156,6 +161,11 @@ class ParticipantPolicy
     public function editAdministrativeAny(User $user)
     {
         return $user->hasCapability("participants::info::edit::administrative");
+    }
+
+    public function editAdministrative(User $user, Participant $participant)
+    {
+        return $this->editAdministrativeAny($user);
     }
 
     public function changePassword(User $user, Participant $participant)


### PR DESCRIPTION
PR is afgetakt van de branch van een andere PR (#135 ) dus die komt in een keer mee, maar die bevat dan ook een security update.

Fixt het niet kunnen zien van admin comments bij deelnemers door kantoorci en bestuur enzo.