### PR TITLE
Patch google tracking code

### DIFF
--- a/config/google.php
+++ b/config/google.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+	/*
+	|--------------------------------------------------------------------------
+	| Google Analytics / Ads tags
+	|--------------------------------------------------------------------------
+	|
+	| These tags are used to track site usage and register specific conversions.
+	|
+	*/
+
+    'site_tag' => env('GOOGLE_SITE_TAG', null),
+
+    'conversion_new_member' => env('GOOGLE_CONVERSION_NEW_MEMBER', null),
+
+    'conversion_new_participant' => env('GOOGLE_CONVERSION_NEW_PARTICIPANT', null),
+
+];

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -48,15 +48,15 @@
 	{{ Html::script('js/vendor.js') }}
 	{{ Html::script('js/app.js') }}
 
-	@if ( env('GOOGLE_SITE_TAG') !== null )
+	@if ( config('google.site_tag') !== null )
 	<!-- Global site tag (gtag.js) - Google Ads -->
-	<script async src="https://www.googletagmanager.com/gtag/js?id={{ env('GOOGLE_SITE_TAG') }}"></script>
+	<script async src="https://www.googletagmanager.com/gtag/js?id={{ config('google.site_tag') }}"></script>
 	<script>
 	window.dataLayer = window.dataLayer || [];
 	function gtag(){dataLayer.push(arguments);}
 	gtag('js', new Date());
 
-	gtag('config', '{{ env("GOOGLE_SITE_TAG") }}');
+	gtag('config', '{{ config("google.site_tag") }}', { 'anonymize_ip': true });
 	</script>
 	@endif
 

--- a/resources/views/registration/iDealResponse.blade.php
+++ b/resources/views/registration/iDealResponse.blade.php
@@ -57,9 +57,9 @@ iDeal betaling mislukt
 
 @section('script')
 
-	@if ( env('GOOGLE_SITE_TAG') !== null && env('GOOGLE_CONVERSION_NEW_PARTICIPANT') !== null)
+	@if ( config('google.site_tag') !== null && config('google.conversion_new_participant') !== null)
 	<script>
-		gtag('event', 'conversion', {'send_to': '{{ env("GOOGLE_SITE_TAG") }}/{{ env("GOOGLE_CONVERSION_NEW_PARTICIPANT") }}'});
+		gtag('event', 'conversion', {'send_to': '{{ config("google.site_tag") }}/{{ config("google.conversion_new_participant") }}'});
 	</script>
 	@endif
 

--- a/resources/views/registration/memberStored.blade.php
+++ b/resources/views/registration/memberStored.blade.php
@@ -26,9 +26,9 @@
 
 @section('script')
 
-	@if ( env('GOOGLE_SITE_TAG') !== null && env('GOOGLE_CONVERSION_NEW_MEMBER') !== null)
+	@if ( config('google.site_tag') !== null && config('google.conversion_new_member') !== null)
 	<script>
-		gtag('event', 'conversion', {'send_to': '{{ env("GOOGLE_SITE_TAG") }}/{{ env("GOOGLE_CONVERSION_NEW_MEMBER") }}'});
+		gtag('event', 'conversion', {'send_to': '{{ config("google.site_tag") }}/{{ config("google.conversion_new_member") }}'});
 	</script>
 	@endif
 

--- a/resources/views/registration/participantStored.blade.php
+++ b/resources/views/registration/participantStored.blade.php
@@ -37,9 +37,9 @@
 
 @section('script')
 
-	@if ( env('GOOGLE_SITE_TAG') !== null && env('GOOGLE_CONVERSION_NEW_PARTICIPANT') !== null)
+	@if ( config('google.site_tag') !== null && config('google.conversion_new_participant') !== null)
 	<script>
-		gtag('event', 'conversion', {'send_to': '{{ env("GOOGLE_SITE_TAG") }}/{{ env("GOOGLE_CONVERSION_NEW_PARTICIPANT") }}'});
+		gtag('event', 'conversion', {'send_to': '{{ config("google.site_tag") }}/{{ config("google.conversion_new_participant") }}'});
 	</script>
 	@endif
 


### PR DESCRIPTION
- Changes direct `env()` calls to using `config()`, otherwise it won't work on production (with cached config)
- Adds `anonymize_ip` option to global tag, because I forgot :')