### PR TITLE
Add role and capability overview page

### DIFF
--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -295,6 +295,10 @@ class PagesController extends Controller
 	# Analytical graphs
 	public function graphs()
 	{
+        if (!\Auth::user()->hasRole("member")) {
+			abort(403, 'Onvoldoende rechten om lijsten in te zien');
+		}
+
 		// Determine end date for graph range; from 1st of August we include the current Anderwijs year
 		$maxYear = Carbon::now()->addMonths(5)->year - 1;
 

--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -296,7 +296,7 @@ class PagesController extends Controller
 	public function graphs()
 	{
         if (!\Auth::user()->hasRole("member")) {
-			abort(403, 'Onvoldoende rechten om lijsten in te zien');
+			abort(403, 'Onvoldoende rechten om grafieken in te zien');
 		}
 
 		// Determine end date for graph range; from 1st of August we include the current Anderwijs year

--- a/app/Http/Controllers/RolesController.php
+++ b/app/Http/Controllers/RolesController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Capability;
+use App\Role;
+use Illuminate\Http\Response;
+
+final class RolesController extends Controller
+{
+    public function explain()
+    {
+        $capabilities = Capability::with('roles')->orderBy('description')->get();
+        $roles = Role::query()->orderBy('title')->get();
+
+        $capabilitiesPerRole = [];
+        /** @var Role $role */
+        foreach ($roles as $role) {
+            $capabilitiesPerRole[$role->id] = $role->capabilities->pluck('id');
+        }
+
+        return view('roles.explain', compact('capabilities', 'capabilitiesPerRole', 'roles'));
+    }
+}

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -9,6 +9,7 @@ Vue.component('flash-message', require('./components/FlashMessage.vue').default)
 Vue.component('declarations-form', require('./components/declarations/DeclarationsForm.vue').default);
 Vue.component('declaration-input-row', require('./components/declarations/DeclarationInputRow.vue').default);
 Vue.component('file-dropzone', require('./components/FileDropzone.vue').default);
+Vue.component('roles-table', require('./components/RolesTable/RolesTable.vue').default);
 Vue.component('errors', require('./components/Errors.vue').default);
 
 const app = new Vue({

--- a/resources/js/components/RolesTable/RolesTable.vue
+++ b/resources/js/components/RolesTable/RolesTable.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="c-roles-explanation">
+    <input v-model="filter" class="form-control" placeholder="Zoek text, zoals: Deelnemer"/>
+    <table class="c-roles-explanation__table">
+      <thead>
+      <tr>
+        <th>
+          <!-- Capability description -->
+        </th>
+
+        <th v-for="role of roles" :key="role.id">{{ role.title }}</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr v-for="capability of filteredCapabilities">
+        <th>{{ capability.description }}</th>
+        <td
+            :class="{
+              'c-roles-explanation__table__cell': true,
+              '--active': capabilitiesPerRole[role.id].includes(capability.id)
+            }"
+            v-for="role of roles"
+            :key="role.id"
+        ></td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+type Capability = {
+  description: string;
+}
+
+export default Vue.extend({
+  props: {
+    roles: Array,
+    capabilities: Array as () => Capability[],
+    capabilitiesPerRole: Object,
+  },
+  data() {
+    return {
+      filter: "" as string,
+    }
+  },
+  computed: {
+    filteredCapabilities(): Capability[]  {
+      const filterValue = this.filter.toLowerCase();
+      if (!filterValue) {
+        return this.capabilities;
+      }
+
+      return this.capabilities.filter((c) => c.description.toLowerCase().includes(filterValue));
+    }
+  }
+});
+</script>

--- a/resources/sass/app.sass
+++ b/resources/sass/app.sass
@@ -4,3 +4,4 @@
  */
 @import './declarations.sass'
 @import './forms.sass'
+@import './roles.sass'

--- a/resources/sass/roles.sass
+++ b/resources/sass/roles.sass
@@ -1,0 +1,49 @@
+.c-roles-explanation
+  position: relative
+  height: 80vh
+
+  overflow: auto
+
+  &__table
+    border-collapse: collapse
+
+    th
+      background: #fff
+      padding: 8px
+
+    thead th
+      position: sticky
+      top: 0
+      border: 0
+      vertical-align: bottom
+      text-align: center
+      z-index: 2
+
+    tbody th
+      position: sticky
+      left: 0
+      z-index: 1
+
+    tr:hover
+      background-color: #f5f5f5
+
+    tbody td
+      position: relative
+
+      &:hover::after
+        content: ""
+        position: absolute
+        background-color: #f5f5f5
+        left: 0
+        top: -5000px
+        height: 5000px
+        width: 100%
+        z-index: -1
+
+    td
+      padding: 4px
+      border-bottom: 1px solid #ddd
+
+    &__cell
+      &.--active
+        background-color: #dff0d8

--- a/resources/views/partials/nav.blade.php
+++ b/resources/views/partials/nav.blade.php
@@ -43,7 +43,10 @@
 									<a href="{{ url('/event-packages') }}">Pakketten</a>
 								</li>
 								@endrole
+
+								@role(["member"])
 								<li class="{{ substr(Request::path(),0,6) == 'graphs' ? 'active' : ''}}"><a href="{{ url('/graphs') }}">Grafieken</a></li>
+								@endrole
 
 								@role(["member"])
 								<li class="{{ substr(Request::path(),0,5) == 'lists' ? 'active' : ''}}"><a href="{{ url('/lists') }}">Lijsten</a></li>

--- a/resources/views/partials/nav.blade.php
+++ b/resources/views/partials/nav.blade.php
@@ -13,52 +13,61 @@
 
 				<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
 					<ul class="nav navbar-nav">
-						
-						@can("viewAny", \App\Participant::class)						
+
+						@can("viewAny", \App\Participant::class)
 						<li class="{{ substr(Request::path(),0,12) == 'participants' ? 'active' : ''}}"><a href="{{ url('/participants') }}">Deelnemers</a></li>
 						@endcan
-						@can("viewAny", \App\Member::class)						
+						@can("viewAny", \App\Member::class)
 						<li class="{{ substr(Request::path(),0,7) == 'members' ? 'active' : ''}}"><a href="{{ url('/members') }}">Leden</a></li>
 						@endcan
 						@can("viewAny", \App\Event::class)
 						<li class="{{ substr(Request::path(),0,6) == 'events' ? 'active' : ''}}"><a href="{{ url('/events') }}">Evenementen</a></li>
 						@endcan
-						@can("viewAny", \App\Location::class)
-						<li class="{{ substr(Request::path(),0,9) == 'locations' ? 'active' : ''}}"><a href="{{ url('/locations') }}">Locaties</a></li>
-						@endcan
 
-						@can("viewAny", \App\Course::class)
-						<li class="{{ substr(Request::path(),0,7) == 'courses' ? 'active' : ''}}"><a href="{{ url('/courses') }}">Vakken</a></li>
-						@endcan
-						@can("viewAny", \App\Action::class)
-						<li class="{{ substr(Request::path(),0,7) == 'actions' ? 'active' : ''}}"><a href="{{ url('/actions') }}">Punten</a></li>
-						@endcan
-						@role(["member"])
-						<li class="{{ substr(Request::path(),0,5) == 'lists' ? 'active' : ''}}"><a href="{{ url('/lists') }}">Lijsten</a></li>
-						@endrole
-						<li class="{{ substr(Request::path(),0,6) == 'graphs' ? 'active' : ''}}"><a href="{{ url('/graphs') }}">Grafieken</a></li>
-						@can("viewAny", \App\User::class)
-						<li class="{{ substr(Request::path(),0,5) == 'users' ? 'active' : ''}}"><a href="{{ url('/users') }}">Gebruikers</a></li>
-						@endcan
-						@role(["board"])
-						<li class="{{ substr(Request::path(),0,5) == 'event-packages' ? 'active' : ''}}">
-							<a href="{{ url('/event-packages') }}">Pakketten</a>
-						</li>
-						@endrole
-						
 						@can("viewOwn", \App\Declaration::class)
 						<li class="{{ substr(Request::path(),0,5) == 'declaration' ? 'active' : ''}}">
 							<a href="{{ url('/declarations') }}">Declaraties</a>
 						</li>
 						@endcan
+
+						<li class="dropdown" >
+							<a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Overig <span class="caret"></span></a>
+							<ul class="dropdown-menu">
+
+								@can("viewAny", \App\Location::class)
+									<li class="{{ substr(Request::path(),0,9) == 'locations' ? 'active' : ''}}"><a href="{{ url('/locations') }}">Locaties</a></li>
+								@endcan
+
+								@role(["board"])
+								<li class="{{ substr(Request::path(),0,5) == 'event-packages' ? 'active' : ''}}">
+									<a href="{{ url('/event-packages') }}">Pakketten</a>
+								</li>
+								@endrole
+								<li class="{{ substr(Request::path(),0,6) == 'graphs' ? 'active' : ''}}"><a href="{{ url('/graphs') }}">Grafieken</a></li>
+
+								@role(["member"])
+								<li class="{{ substr(Request::path(),0,5) == 'lists' ? 'active' : ''}}"><a href="{{ url('/lists') }}">Lijsten</a></li>
+								@endrole
+
+								@can("viewAny", \App\Course::class)
+									<li class="{{ substr(Request::path(),0,7) == 'courses' ? 'active' : ''}}"><a href="{{ url('/courses') }}">Vakken</a></li>
+								@endcan
+
+								@can("viewAny", \App\Action::class)
+									<li class="{{ substr(Request::path(),0,7) == 'actions' ? 'active' : ''}}"><a href="{{ url('/actions') }}">Punten</a></li>
+								@endcan
+
+								<li class="{{ substr(Request::path(),0,5) == 'roles' ? 'active' : ''}}"><a href="{{ url('/roles/explain') }}">Rollen en rechten</a></li>
+							</ul>
+						</li>
 					</ul>
-					
+
 					<ul class="nav navbar-nav navbar-right">
-					
+
 						<li class="{{ substr(Request::path(),0,7) == 'profile' ? 'active' : ''}}"><a href="{{ url('/profile') }}">Mijn profiel</a></li>
-						
+
 						<li><a href="{{ url('/logout') }}">Uitloggen</a></li>
-						
+
 					</ul>
 				</div>
 			</div>

--- a/resources/views/roles/explain.blade.php
+++ b/resources/views/roles/explain.blade.php
@@ -5,29 +5,9 @@ Rollen en Rechten
 @endsection
 
 @section('content')
-<div class="c-roles-explanation">
-    <table class="c-roles-explanation__table">
-        <thead>
-            <tr>
-                <th>
-                    <!-- Capability description -->
-                </th>
-                @foreach($roles as $role)
-                    <th>{{$role->title}}</th>
-                @endforeach
-            </tr>
-        </thead>
-        <tbody>
-            @foreach($capabilities as $capability)
-            <tr>
-                <th>{{ $capability->description }}</th>
-                @foreach($roles as $role)
-                    <td class="c-roles-explanation__table__cell @if($capabilitiesPerRole[$role->id]->contains($capability->id)) --active @endif"></td>
-                @endforeach
-            </tr>
-            @endforeach
-        </tbody>
-    </table>
-</div>
+<roles-table
+    :roles='@json($roles)'
+    :capabilities='@json($capabilities)'
+    :capabilities-per-role='@json($capabilitiesPerRole)'
+></roles-table>
 @endsection
-

--- a/resources/views/roles/explain.blade.php
+++ b/resources/views/roles/explain.blade.php
@@ -1,0 +1,33 @@
+@extends('master')
+
+@section('title')
+Rollen en Rechten
+@endsection
+
+@section('content')
+<div class="c-roles-explanation">
+    <table class="c-roles-explanation__table">
+        <thead>
+            <tr>
+                <th>
+                    <!-- Capability description -->
+                </th>
+                @foreach($roles as $role)
+                    <th>{{$role->title}}</th>
+                @endforeach
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($capabilities as $capability)
+            <tr>
+                <th>{{ $capability->description }}</th>
+                @foreach($roles as $role)
+                    <td class="c-roles-explanation__table__cell @if($capabilitiesPerRole[$role->id]->contains($capability->id)) --active @endif"></td>
+                @endforeach
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>
+@endsection
+

--- a/routes/web.auth.php
+++ b/routes/web.auth.php
@@ -43,7 +43,7 @@ Route::get("accept-privacy", "PagesController@showAcceptPrivacyStatement")->name
 Route::post("accept-privacy", "PagesController@storePrivacyStatement")->name("store-accept-privacy");
 
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
-
+Route::get("roles/explain", "RolesController@explain")->name("roles.explain");
 
 # Declaration things
 Route::get(

--- a/tests/Feature/RolesTest.php
+++ b/tests/Feature/RolesTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class RolesTest extends TestCase
+{
+    public $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = \App\User::findOrFail(1);
+    }
+
+    public function testIndex()
+    {
+        $this
+            ->actingAs($this->user)
+            ->get('/roles/explain')
+            ->assertStatus(200)
+            ->assertSee('Aasbaas', 'Deelnemersinfo - Inzien');
+    }
+
+    public function testShowUnauthorized()
+    {
+        $this
+            ->get('/roles/explain')
+            ->assertStatus(302);
+    }
+
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,7 @@
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+     "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */


### PR DESCRIPTION
Related to #200

## What has been done
- Overview page for roles + capabilities
- The menu was way to crowded, I opted to create a dropdown with bootstrap

## How to test

- Navigate to: "overig -> Rollen en Rechten"
- See role rights tables

## What needs to be done

- Add a better description to as a hover to the capabilities
- Add users which belong to certain roles (maxed to 5 persons)
- Maybe we need to think about displaying or searching. it is quite the amount of information.
