### PR TITLE
Action persistance with events

### DIFF
--- a/app/Console/Commands/FinalizeEvents.php
+++ b/app/Console/Commands/FinalizeEvents.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Event;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class FinalizeEvents extends Command
+{
+    protected $signature = 'events:finalize
+        {--event= : Finalize a specific event}
+    ';
+
+    protected $description = 'Finalize events';
+
+    public function handle(): int
+    {
+        if (! $this->option('event')) {
+            $eventToFinalize = Event::query()
+                ->whereNull('finalized_at')
+                ->where('datum_eind', '<', Carbon::now())
+                ->get();
+        } else {
+            $eventToFinalize = [Event::findOrFail($this->option('event'))];
+        }
+
+        /** @var Event $event */
+        foreach ($eventToFinalize as $event) {
+            $this->output->info('Finalizing ' . $event->code);
+            $event->finalize();
+        }
+
+        return 0;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console;
 
+use App\Console\Commands\FinalizeEvents;
 use App\Console\Commands\MemberGeolocations;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
@@ -24,5 +25,6 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         $schedule->command(MemberGeolocations::class)->monthly();
+        $schedule->command(FinalizeEvents::class)->at('12:00');
     }
 }

--- a/app/Events/FinishedEvent.php
+++ b/app/Events/FinishedEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\Event as EventModel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+final class FinishedEvent
+{
+    use Dispatchable;
+
+    use InteractsWithSockets;
+
+    use SerializesModels;
+
+    private EventModel $event;
+
+    public function __construct(
+        EventModel $event
+    ) {
+        $this->event = $event;
+    }
+
+    public function getEvent(): EventModel
+    {
+        return $this->event;
+    }
+}

--- a/app/Listeners/AddMemberActionForFinishedEvent.php
+++ b/app/Listeners/AddMemberActionForFinishedEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\FinishedEvent;
+use App\Member;
+use App\Services\ActionGenerator\EventActionApplicator;
+use App\Services\ActionGenerator\ValueObject\EventActionInput;
+
+final class AddMemberActionForFinishedEvent
+{
+    /**
+     * @var iterable<EventActionApplicator>
+     */
+    private iterable $applicators;
+
+    /**
+     * @param iterable<EventActionApplicator> $applicators
+     */
+    public function __construct(
+        iterable $applicators
+    ) {
+        $this->applicators = $applicators;
+    }
+
+    public function handle(FinishedEvent $finishedEvent)
+    {
+        $members = $finishedEvent->getEvent()->members;
+        /** @var Member $member */
+        foreach ($members as $member) {
+            $input = new EventActionInput($finishedEvent->getEvent(), $member, (bool) $member->pivot->wissel);
+            foreach ($this->applicators as $applicator) {
+                if (! $applicator->shouldApply($input)) {
+                    continue;
+                }
+
+                $applicator->apply($input);
+            }
+        }
+    }
+}

--- a/app/Models/Action.php
+++ b/app/Models/Action.php
@@ -10,10 +10,15 @@ class Action extends Model
 {
     protected $guarded = ['id', 'created_at', 'updated_at'];
 
-    // Carbon dates
     protected $dates = ['date'];
 
-    // An action belongs to one member
+    public static function empty(): self
+    {
+        return new self([
+            'description' => '-',
+            'points' => 0,
+        ]);
+    }
 
     public function member()
     {

--- a/app/Services/ActionGenerator/EventActionApplicator.php
+++ b/app/Services/ActionGenerator/EventActionApplicator.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\ActionGenerator;
+
+use App\Services\ActionGenerator\ValueObject\EventActionInput;
+
+interface EventActionApplicator
+{
+    public function shouldApply(EventActionInput $input): bool;
+
+    public function apply(EventActionInput $input): void;
+}

--- a/app/Services/ActionGenerator/EventSingleActionApplicator.php
+++ b/app/Services/ActionGenerator/EventSingleActionApplicator.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\ActionGenerator;
+
+use App\Models\Action;
+use App\Services\ActionGenerator\ValueObject\EventActionInput;
+
+final class EventSingleActionApplicator implements EventActionApplicator
+{
+    public function shouldApply(EventActionInput $input): bool
+    {
+        return ! $input->getEvent()->cancelled
+            && $input->getMember()->actions()->where('code', $this->getCode($input))->doesntExist();
+    }
+
+    public function apply(EventActionInput $input): void
+    {
+        $action = new Action();
+
+        $action->points = $this->getEventActionPoints($input);
+        $action->description = $this->getEventActionDescription($input);
+        $action->date = $input->getEvent()->datum_start;
+        $action->code = $input->getEvent()->code;
+        $action->member()->associate($input->getMember());
+
+        $action->save();
+    }
+
+    private function getEventActionDescription(EventActionInput $input): string
+    {
+        return $input->getEvent()->naam . ' '
+            . $input->getEvent()->datum_start->format('Y')
+            . ($input->isWissel() ? ' (w)' : '');
+    }
+
+    private function getEventActionPoints(EventActionInput $input): int
+    {
+        if ($input->getEvent()->type === 'training') {
+            return 2;
+        }
+
+        if ($input->isWissel()) {
+            return 1;
+        }
+
+        return 3;
+    }
+
+    private function getCode(EventActionInput $input): string
+    {
+        return $input->getEvent()->code;
+    }
+}

--- a/app/Services/ActionGenerator/EventSingleActionApplicator.php
+++ b/app/Services/ActionGenerator/EventSingleActionApplicator.php
@@ -9,6 +9,12 @@ use App\Services\ActionGenerator\ValueObject\EventActionInput;
 
 final class EventSingleActionApplicator implements EventActionApplicator
 {
+    private const POINTS_TRAINING = 2;
+
+    private const POINTS_CAMP_FULL = 3;
+
+    private const POINTS_CAMP_PARTIAL = 1;
+
     public function shouldApply(EventActionInput $input): bool
     {
         return ! $input->getEvent()->cancelled
@@ -38,14 +44,14 @@ final class EventSingleActionApplicator implements EventActionApplicator
     private function getEventActionPoints(EventActionInput $input): int
     {
         if ($input->getEvent()->type === 'training') {
-            return 2;
+            return self::POINTS_TRAINING;
         }
 
         if ($input->isWissel()) {
-            return 1;
+            return self::POINTS_CAMP_PARTIAL;
         }
 
-        return 3;
+        return self::POINTS_CAMP_FULL;
     }
 
     private function getCode(EventActionInput $input): string

--- a/app/Services/ActionGenerator/EventStraightFlushActionApplicator.php
+++ b/app/Services/ActionGenerator/EventStraightFlushActionApplicator.php
@@ -11,13 +11,17 @@ final class EventStraightFlushActionApplicator implements EventActionApplicator
 {
     public const STRAIGHT_FLUSH_CODE = 'straight_flush';
 
+    private const POINTS_STRAIGHT_FLUSH = 3;
+
+    private const REQUIRED_NUMBER_OF_CAMP_TYPES = 5;
+
     private const CUT_OFF_DATE = '2014-09-01';
 
     public function apply(EventActionInput $input): void
     {
         $action = new Action();
 
-        $action->points = 3;
+        $action->points = self::POINTS_STRAIGHT_FLUSH;
         $action->description = 'Straight flush';
         $action->date = $input->getEvent()->datum_start;
         $action->code = self::STRAIGHT_FLUSH_CODE;
@@ -48,10 +52,11 @@ final class EventStraightFlushActionApplicator implements EventActionApplicator
 
         $codes = array_unique($codes);
 
+        // Treat K and N camps the same; 'Kerst kamp' and Nieuwjaars kamp' are seen as the same type of camp
         if (in_array('K', $codes, true) && in_array('N', $codes, true)) {
             $codes = array_diff($codes, ['K']);
         }
 
-        return ! (count($codes) < 5);
+        return ! (count($codes) < self::REQUIRED_NUMBER_OF_CAMP_TYPES);
     }
 }

--- a/app/Services/ActionGenerator/EventStraightFlushActionApplicator.php
+++ b/app/Services/ActionGenerator/EventStraightFlushActionApplicator.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\ActionGenerator;
+
+use App\Models\Action;
+use App\Services\ActionGenerator\ValueObject\EventActionInput;
+
+final class EventStraightFlushActionApplicator implements EventActionApplicator
+{
+    public const STRAIGHT_FLUSH_CODE = 'straight_flush';
+
+    private const CUT_OFF_DATE = '2014-09-01';
+
+    public function apply(EventActionInput $input): void
+    {
+        $action = new Action();
+
+        $action->points = 3;
+        $action->description = 'Straight flush';
+        $action->date = $input->getEvent()->datum_start;
+        $action->code = self::STRAIGHT_FLUSH_CODE;
+
+        $action->member()->associate($input->getMember());
+
+        $action->save();
+    }
+
+    public function shouldApply(EventActionInput $input): bool
+    {
+        if ($input->getMember()->actions()->where('code', self::STRAIGHT_FLUSH_CODE)->exists()) {
+            return false;
+        }
+
+        $codes = $input->getMember()->events()
+            ->where('type', 'kamp')
+            ->whereBetween('datum_start', [
+                self::CUT_OFF_DATE,
+                $input->getEvent()->datum_start->year . '-12-31',
+            ])
+            ->where('wissel', 0)
+            ->selectRaw('SUBSTRING(code, 1, 1) as code')
+            ->distinct()
+            ->get('code')
+            ->map(fn (object $data) => $data['code'])
+            ->toArray();
+
+        $codes = array_unique($codes);
+
+        if (in_array('K', $codes, true) && in_array('N', $codes, true)) {
+            $codes = array_diff($codes, ['K']);
+        }
+
+        return ! (count($codes) < 5);
+    }
+}

--- a/app/Services/ActionGenerator/ValueObject/EventActionInput.php
+++ b/app/Services/ActionGenerator/ValueObject/EventActionInput.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\ActionGenerator\ValueObject;
+
+use App\Models\Event;
+use App\Models\Member;
+
+final class EventActionInput
+{
+    private Event $event;
+
+    private Member $member;
+
+    private bool $wissel;
+
+    public function __construct(
+        Event $event,
+        Member $member,
+        bool $wissel
+    ) {
+        $this->event = $event;
+        $this->member = $member;
+        $this->wissel = $wissel;
+    }
+
+    public function getEvent(): Event
+    {
+        return $this->event;
+    }
+
+    public function getMember(): Member
+    {
+        return $this->member;
+    }
+
+    public function isWissel(): bool
+    {
+        return $this->wissel;
+    }
+}

--- a/database/migrations/2021_10_27_225546_add_action_unique_code.php
+++ b/database/migrations/2021_10_27_225546_add_action_unique_code.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+final class AddActionUniqueCode extends Migration
+{
+    public function up()
+    {
+        Schema::table('actions', function (Blueprint $table) {
+            $table->string('code')
+                ->nullable(true)
+                ->default(null);
+
+            $table->unique(['member_id', 'code']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('actions', function (Blueprint $table) {
+            $table->dropColumn('code');
+        });
+    }
+}

--- a/database/migrations/2021_10_28_205631_add_event_finalized_date.php
+++ b/database/migrations/2021_10_28_205631_add_event_finalized_date.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddEventFinalizedDate extends Migration
+{
+    public function up()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dateTime('finalized_at')
+                ->nullable(true);
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('finalized_at');
+        });
+    }
+}

--- a/resources/views/members/show.blade.php
+++ b/resources/views/members/show.blade.php
@@ -221,7 +221,7 @@ Mijn profiel
 		<div class="row">
 			<div class="col-md-7">
 				<br />
-				Meest recente actie: {{$member->most_recent_action['name']}} ({{$member->most_recent_action['points']}} pt)
+				Meest recente actie: {{$member->most_recent_action['description']}} ({{$member->most_recent_action['points']}} pt)
 			</div>
 			<div class="col-md-5 text-right">
 				<br />
@@ -517,10 +517,10 @@ Mijn profiel
 						</tr>
 					</thead>
 					<tbody>
-						@foreach ($member->list_of_actions as $item)
+						@foreach ($member->actions as $item)
 						<tr>
 							<td>{{ $item['date'] !== null ? $item['date']->format('d-m-Y') : '' }}</td>
-							<td>{{ $item['name'] }}</td>
+							<td>{{ $item['description'] }}</td>
 							<td>{{ $item['points'] }}</td>
 						</tr>
 						@endforeach

--- a/tests/Feature/CommentTest.php
+++ b/tests/Feature/CommentTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit;
+namespace Tests\Feature;
 
 use App\Http\Controllers\CommentsController;
 use App\Models\Comment;

--- a/tests/Unit/EventFinalizeTest.php
+++ b/tests/Unit/EventFinalizeTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Events\FinishedEvent;
+use App\Models\Event;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+final class EventFinalizeTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function testItEmitsFinalizeEvent(): void
+    {
+        $this->expectsEvents([FinishedEvent::class]);
+        $event = new Event();
+
+        $event->finalize();
+    }
+
+    public function testItSetsFinished(): void
+    {
+        $event = new Event();
+        self::assertNull($event->finalized_at);
+
+        $event->finalize();
+
+        self::assertNotNull($event->finalized_at);
+    }
+
+    public function testItDoesntDoAnythingWhenAlreadyFinished(): void
+    {
+        $this->doesntExpectEvents(FinishedEvent::class);
+        $originalDate = Carbon::create('2021-10-10');
+        $event = new Event();
+        $event->finalized_at = $originalDate;
+
+        $event->finalize();
+
+        self::assertSame($originalDate, $event->finalized_at);
+    }
+}

--- a/tests/Unit/Listeners/AddMemberActionForFinishedEventTest.php
+++ b/tests/Unit/Listeners/AddMemberActionForFinishedEventTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Listeners;
+
+use App\Events\FinishedEvent;
+use App\Listeners\AddMemberActionForFinishedEvent;
+use App\Models\Event;
+use App\Models\Member;
+use App\Services\ActionGenerator\EventActionApplicator;
+use App\Services\ActionGenerator\ValueObject\EventActionInput;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+final class AddMemberActionForFinishedEventTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function testItCallsMultipleApplicators(): void
+    {
+        /** @var Event $event */
+        $event = Event::create();
+        /** @var Member $member */
+        $member = Member::create();
+        $event->members()->save($member);
+
+        $applicator1 = \Mockery::mock(EventActionApplicator::class);
+        $applicator1
+            ->expects('shouldApply')
+            ->withArgs(self::withInputArg($event, $member))
+            ->andReturn(true);
+
+        $applicator1
+            ->expects('apply')
+            ->withArgs(self::withInputArg($event, $member));
+
+        $applicator2 = \Mockery::mock(EventActionApplicator::class);
+        $applicator2
+            ->expects('shouldApply')
+            ->withArgs(self::withInputArg($event, $member))
+            ->andReturn(false);
+
+        $subject = new AddMemberActionForFinishedEvent([$applicator1, $applicator2]);
+
+        $subject->handle(new FinishedEvent($event));
+    }
+
+    public function testItCallsForMultiplyMembers(): void
+    {
+        /** @var Event $event */
+        $event = Event::create();
+        /** @var Member $member */
+        $member1 = Member::create();
+        $member2 = Member::create();
+        $event->members()->saveMany([$member1, $member2]);
+
+        $applicator = \Mockery::mock(EventActionApplicator::class);
+        $applicator
+            ->expects('shouldApply')
+            ->withArgs(self::withInputArg($event, $member1))
+            ->andReturn(true);
+
+        $applicator
+            ->expects('apply')
+            ->withArgs(self::withInputArg($event, $member1));
+
+        $applicator
+            ->expects('shouldApply')
+            ->withArgs(self::withInputArg($event, $member2))
+            ->andReturn(false);
+
+        $subject = new AddMemberActionForFinishedEvent([$applicator]);
+
+        $subject->handle(new FinishedEvent($event));
+    }
+
+    private static function withInputArg(Event $event, Member $member): callable
+    {
+        return static function (EventActionInput $input) use ($member, $event) {
+            return $input->getMember()->is($member)
+                && $input->getEvent()->is($event);
+        };
+    }
+}

--- a/tests/Unit/Services/ActionGenerator/EventActionInputFaker.php
+++ b/tests/Unit/Services/ActionGenerator/EventActionInputFaker.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\ActionGenerator;
+
+use App\Models\Action;
+use App\Models\Event;
+use App\Models\Member;
+use App\Services\ActionGenerator\ValueObject\EventActionInput;
+use Carbon\Carbon;
+
+final class EventActionInputFaker
+{
+    private array $codes = [];
+
+    private bool $wissel = false;
+
+    private array $eventData;
+
+    private function __construct()
+    {
+        $this->eventData = [
+            'code' => ':code:',
+            'description' => ':description:',
+            'datum_start' => Carbon::now(),
+            'type' => 'kamp',
+        ];
+    }
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function withAction(string $code = ':code:', int $points = 3, string $description = ':description:'): self
+    {
+        $act = new Action();
+
+        $act->fill([
+            'code' => $code,
+            'points' => $points,
+            'description' => $description,
+        ]);
+
+        $this->codes[] = $act;
+        return $this;
+    }
+
+    public function withWissel(bool $wissel = true): self
+    {
+        $this->wissel = $wissel;
+        return $this;
+    }
+
+    public function withEventData(
+        string $code = 'K2122',
+        string $description = ':description:',
+        string $dateStart = '2021-10-11',
+        string $type = 'kamp'
+    ): self {
+        $this->eventData['code'] = $code;
+        $this->eventData['naam'] = $description;
+        $this->eventData['datum_start'] = Carbon::create($dateStart);
+        $this->eventData['type'] = $type;
+
+        return $this;
+    }
+
+    public function withEventType(string $type): self
+    {
+        $this->eventData['type'] = $type;
+
+        return $this;
+    }
+
+    public function build(): EventActionInput
+    {
+        $event = Event::create($this->eventData);
+        $member = Member::create();
+
+        $member->actions()->saveMany($this->codes);
+
+        return new EventActionInput($event, $member, $this->wissel);
+    }
+
+    public function withCancelledEvent(): self
+    {
+        $this->eventData['cancelled_at'] = Carbon::now();
+        return $this;
+    }
+}

--- a/tests/Unit/Services/ActionGenerator/EventSingleActionApplicatorTest.php
+++ b/tests/Unit/Services/ActionGenerator/EventSingleActionApplicatorTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\ActionGenerator;
+
+use App\Services\ActionGenerator\EventSingleActionApplicator;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+final class EventSingleActionApplicatorTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private EventSingleActionApplicator $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new EventSingleActionApplicator();
+    }
+
+    public function testItShouldNotApplyForExistingCode(): void
+    {
+        $input = EventActionInputFaker::create()
+            ->withAction('123', )
+            ->withEventData('123')
+            ->build();
+
+        self::assertFalse($this->subject->shouldApply($input));
+    }
+
+    public function testItShouldNotApplyForCancalledEvent(): void
+    {
+        $input = EventActionInputFaker::create()
+            ->withCancelledEvent()
+            ->build();
+
+        self::assertFalse($this->subject->shouldApply($input));
+    }
+
+    public function testItShouldApply(): void
+    {
+        $input = EventActionInputFaker::create()
+            ->build();
+
+        self::assertTrue($this->subject->shouldApply($input));
+    }
+
+    public function testItAppliesMemberAction(): void
+    {
+        $input = EventActionInputFaker::create()
+            ->withEventData('123', 'test event', '2021-10-11')
+            ->build();
+
+        $this->subject->apply($input);
+
+        $this->assertDatabaseHas('actions', [
+            'member_id' => $input->getMember()->id,
+            'code' => '123',
+            'description' => 'test event 2021',
+            'points' => 3,
+        ]);
+    }
+
+    public function testItAppliesWisselAction(): void
+    {
+        $input = EventActionInputFaker::create()
+            ->withEventData('123', 'test event', '2021-10-11')
+            ->withWissel()
+            ->build();
+
+        $this->subject->apply($input);
+
+        $this->assertDatabaseHas('actions', [
+            'member_id' => $input->getMember()->id,
+            'code' => '123',
+            'description' => 'test event 2021 (w)',
+            'points' => 1,
+        ]);
+    }
+
+    public function testItAppliesTrainingAction(): void
+    {
+        $input = EventActionInputFaker::create()
+            ->withEventData('123', 'test event', '2021-10-11', 'training')
+            ->build();
+
+        $this->subject->apply($input);
+
+        $this->assertDatabaseHas('actions', [
+            'member_id' => $input->getMember()->id,
+            'code' => '123',
+            'description' => 'test event 2021',
+            'points' => 2,
+        ]);
+    }
+}

--- a/tests/Unit/Services/ActionGenerator/EventSingleActionApplicatorTest.php
+++ b/tests/Unit/Services/ActionGenerator/EventSingleActionApplicatorTest.php
@@ -31,7 +31,7 @@ final class EventSingleActionApplicatorTest extends TestCase
         self::assertFalse($this->subject->shouldApply($input));
     }
 
-    public function testItShouldNotApplyForCancalledEvent(): void
+    public function testItShouldNotApplyForCancelledEvent(): void
     {
         $input = EventActionInputFaker::create()
             ->withCancelledEvent()

--- a/tests/Unit/Services/ActionGenerator/EventStraightFlushActionApplicatorTest.php
+++ b/tests/Unit/Services/ActionGenerator/EventStraightFlushActionApplicatorTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\ActionGenerator;
+
+use App\Models\Event;
+use App\Models\Member;
+use App\Services\ActionGenerator\EventStraightFlushActionApplicator;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+final class EventStraightFlushActionApplicatorTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private EventStraightFlushActionApplicator $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = new EventStraightFlushActionApplicator();
+    }
+
+    public function testItShouldNotApplyCancelledEvent(): void
+    {
+        $input = EventActionInputFaker::create()
+            ->withCancelledEvent()
+            ->build();
+
+        self::assertFalse($this->subject->shouldApply($input));
+    }
+
+    public function testItShouldNotApplyWithExistingAction(): void
+    {
+        $input = EventActionInputFaker::create()
+            ->withAction('123')
+            ->withEventData('123')
+            ->build();
+
+        self::assertFalse($this->subject->shouldApply($input));
+    }
+
+    /**
+     * @dataProvider eventCodesDataProvider
+     */
+    public function testItShouldApplyWithEvents(array $eventCodes, bool $expected): void
+    {
+        $input = EventActionInputFaker::create()
+            ->withEventData('K2122', 'test', '2021-11-12')
+            ->build();
+
+        $this->attachNewEventsWithCodes($input->getMember(), $eventCodes);
+
+        self::assertSame($expected, $this->subject->shouldApply($input));
+    }
+
+    public function eventCodesDataProvider(): \Generator
+    {
+        yield 'should apply' => [
+            ['V1920', 'K1920', 'Z2021', 'H2021', 'M2021'], true,
+        ];
+        yield 'should not apply with to less' => [
+            ['V1920', 'K1920', 'Z2021', 'H2021'], false,
+        ];
+        yield 'should not apply with duplicates' => [
+            ['V1920', 'K1920', 'Z2021', 'Z1920', 'H2021'], false,
+        ];
+        yield 'should not apply; reduces K and N eventcodes to the same' => [
+            ['V1920', 'K1920', 'Z2021', 'N1819', 'H2021'], false,
+        ];
+    }
+
+    public function testItApplyAddsStraightFlush(): void
+    {
+        $input = EventActionInputFaker::create()
+            ->build();
+
+        $this->subject->apply($input);
+
+        $this->assertDatabaseHas('actions', [
+            'member_id' => $input->getMember()->id,
+            'description' => 'Straight flush',
+            'code' => 'straight_flush',
+            'points' => 3,
+        ]);
+    }
+
+    private function attachNewEventsWithCodes(Member $member, array $eventCodes): void
+    {
+        $events = array_map(
+            fn (string $code) => Event::create([
+                'code' => $code,
+                'datum_start' => '2020-09-08',
+            ]),
+            $eventCodes
+        );
+
+        $member->events()->attach(
+            array_map(fn (Event $event) => $event->id, $events),
+            [
+                'wissel' => 0,
+            ]
+        );
+
+        $member->events()->attach(
+            array_map(fn (Event $event) => $event->id, $events),
+            [
+                'wissel' => 0,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Add persistent of actions through the use of an scheduled command, an event and listener.

## How to test

- After migrating (or migrate fresh, because the actions are only created when running the command)
- Run `artisan events:finalize`
- See actions for Jon Snow and Ranonkeltje
