### PR TITLE
Add not cancelled to thermometer query scope

### DIFF
--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -50,6 +50,7 @@ class PagesController extends Controller
             // Camp thermometer
             $camps = Event::ParticipantEvent()
                 ->ongoing()
+                ->notCancelled()
                 ->public()
                 ->orderBy('datum_start')
                 ->take(2)


### PR DESCRIPTION
Want het is beetje vreemd dat Lentekamp nu nog zichtbaar is in de kampthermometer op de homepage terwijl die is afgelast