### PR TITLE
Fix: if member isUser null bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,8 @@ bootstrap/cache
 # AAS2 specifics
 /public/img
 /public/uploads
+/public/.ftp-deploy-sync-state.json
+/config/updater.php
 
 # Ignore the composer archive
 # It's required on server (can't install globally) but updating interferes with git pull

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -200,7 +200,7 @@ class Member extends Model
 
     public function isUser(User $user)
     {
-        return $this->user->id === $user->id;
+        return $this->user !== null && $this->user->id === $user->id;
     }
 
     public function formSkillsAttribute($value)


### PR DESCRIPTION
`$member->isUser($user)` wordt oa gebruikt bij capability checks. Maar oud-leden hebben geen user meer...