### PR TITLE
Fix declaration delete endpoint and use policy to check permission

### DIFF
--- a/app/Http/Controllers/DeclarationsController.php
+++ b/app/Http/Controllers/DeclarationsController.php
@@ -128,18 +128,9 @@ class DeclarationsController extends Controller
         ]);
     }
 
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  int  $declaration
-     * @return Response
-     */
     public function delete(Declaration $declaration)
     {
-        $member = \Auth::user()->profile;
-        if ($member !== $declaration->member) {
-            return redirect()->back();
-        }
+        $this->authorize('delete', $declaration);
 
         return view('declarations.delete', compact('declaration'));
     }


### PR DESCRIPTION
## HTT

Happy flow
- Add a declaration as a normal member (dkrijgsman)
- delete the declaration
- See it succeed

Permission check
- Add a declaration as a normal member (dkrijgsman)
- The the url of the delete endpoint (delete but not confirm deletion)
- Login as another member without explicit declaration permissions (promoci)
- Try to access the delete confirmation endpoint 
- See access denied.