### PR TITLE
fix member reviews specific to one event

### DIFF
--- a/app/Services/Chart/LavachartsChartService.php
+++ b/app/Services/Chart/LavachartsChartService.php
@@ -119,6 +119,7 @@ class LavachartsChartService implements ChartServiceInterface
 
         $entity = $member ?? $event;
         $q = $entity->reviews()
+            ->where('event_id', $event->id)
             ->select($question, DB::raw('count(*) as total'))
             ->groupBy($question)
             ->pluck('total', $question)->toArray();


### PR DESCRIPTION
Probleem: bij je persoonlijke reviews (via je profiel, als member) werden je reviews van *alle* kampen getoond, in plaats van voor het kamp dat je geselecteerd hebt.

Oplossing: dit.