### PR TITLE
Improvements to camp year map

### DIFF
--- a/app/Http/Controllers/CampYearMapController.php
+++ b/app/Http/Controllers/CampYearMapController.php
@@ -15,7 +15,7 @@ class CampYearMapController extends Controller
     {
         $camps = Event::where('type', 'kamp')->ended()->notCancelled()
             ->whereHas('location', function (Builder $query) {
-                return $query->whereNotNull('geolocatie');
+                return $query->where('naam', '<>', 'Onbekend')->whereNotNull('geolocatie');
             })
             ->orderBy('datum_start')
             ->get()

--- a/app/ValueObjects/CampMapData.php
+++ b/app/ValueObjects/CampMapData.php
@@ -16,18 +16,22 @@ final class CampMapData
 
     public array $latlng;
 
-    public int $num_members;
+    public int $numMembers;
 
-    public int $num_participants;
+    public int $numParticipants;
 
-    public function __construct(int $id, string $title, string $verenigingsjaar, array $latlng, int $num_members, int $num_participants)
+    public int $size;
+
+    public function __construct(int $id, string $title, string $verenigingsjaar, array $latlng, int $numMembers, int $numParticipants)
     {
         $this->id = $id;
         $this->title = $title;
         $this->verenigingsjaar = $verenigingsjaar;
         $this->latlng = $latlng;
-        $this->num_members = $num_members;
-        $this->num_participants = $num_participants;
+        $this->numMembers = $numMembers;
+        $this->numParticipants = $numParticipants;
+
+        $this->size = $numMembers + $numParticipants;
     }
 
     public static function fromEvent(Event $event): static

--- a/app/ValueObjects/CampMapData.php
+++ b/app/ValueObjects/CampMapData.php
@@ -16,15 +16,18 @@ final class CampMapData
 
     public array $latlng;
 
-    public int $size;
+    public int $num_members;
 
-    public function __construct(int $id, string $title, string $verenigingsjaar, array $latlng, int $size)
+    public int $num_participants;
+
+    public function __construct(int $id, string $title, string $verenigingsjaar, array $latlng, int $num_members, int $num_participants)
     {
         $this->id = $id;
         $this->title = $title;
         $this->verenigingsjaar = $verenigingsjaar;
         $this->latlng = $latlng;
-        $this->size = $size;
+        $this->num_members = $num_members;
+        $this->num_participants = $num_participants;
     }
 
     public static function fromEvent(Event $event): static
@@ -35,7 +38,8 @@ final class CampMapData
             $event->full_title,
             $event->verenigingsjaar,
             [$loc->geolocatie->getLat(), $loc->geolocatie->GetLng()],
-            $event->members()->count() + $event->participants()->count()
+            $event->members()->wherePivot('wissel', 0)->count(),
+            $event->participants()->count()
         );
     }
 }

--- a/resources/js/components/CampYearMap.vue
+++ b/resources/js/components/CampYearMap.vue
@@ -16,12 +16,12 @@
         v-for="x in filteredCampData"
         :key="x.id"
         :lat-lng="x.latlng"
-        :radius="(x.num_members + x.num_participants) * 2" 
+        :radius="x.size * 2" 
         color="#95184d"
         fill-color="#95184d"
         ><l-tooltip>
           {{ x.title }}<br/>
-          {{ x.num_participants }} deelnemers, {{ x.num_members }} leiding
+          {{ x.numParticipants }} deelnemers, {{ x.numMembers }} leiding
         </l-tooltip>
       </l-circle-marker>
     </l-map>
@@ -49,8 +49,9 @@ type CampMapData = {
   title: string;
   verenigingsjaar: string;
   latlng: Array<number>;
-  num_members: number;
-  num_participants: number;
+  numMembers: number;
+  numParticipants: number;
+  size: number;
 };
 
 const NETHERLANDS_CENTER_LAT_LNG = [52.1, 5.4];

--- a/resources/js/components/CampYearMap.vue
+++ b/resources/js/components/CampYearMap.vue
@@ -16,10 +16,12 @@
         v-for="x in filteredCampData"
         :key="x.id"
         :lat-lng="x.latlng"
-        :radius="x.size * 2"
-        color="red"
+        :radius="(x.num_members + x.num_participants) * 2" 
+        color="#95184d"
+        fill-color="#95184d"
         ><l-tooltip>
-          {{ x.title }}
+          {{ x.title }}<br/>
+          {{ x.num_participants }} deelnemers, {{ x.num_members }} leiding
         </l-tooltip>
       </l-circle-marker>
     </l-map>
@@ -47,7 +49,8 @@ type CampMapData = {
   title: string;
   verenigingsjaar: string;
   latlng: Array<number>;
-  size: number;
+  num_members: number;
+  num_participants: number;
 };
 
 const NETHERLANDS_CENTER_LAT_LNG = [52.1, 5.4];


### PR DESCRIPTION
- Better marker colors: Anderwijs purple/pink!
- Tooltips show number of members and participants
- Don't count "wisselleiding" in camp size
- Filter out locations "Onbekend"