### PR TITLE
add csrf tokens to anonymize forms

### DIFF
--- a/resources/views/participants/anonymize.blade.php
+++ b/resources/views/participants/anonymize.blade.php
@@ -7,6 +7,7 @@
 
 @section('content')
     <form action="{{ action('ParticipantsController@anonymizeConfirm') }}">
+        @csrf
         <table class="table table-hover">
             <thead>
                 <tr>

--- a/resources/views/participants/anonymizeConfirm.blade.php
+++ b/resources/views/participants/anonymizeConfirm.blade.php
@@ -8,6 +8,7 @@
     Weet je zeker dat je {{ count($participants) }} deelnemers wil anonimiseren?
 
     <form method="post">
+        @csrf
         <ul>
             @foreach ($participants as $participant)
                 <input type="hidden" name="participants[]" value="{{$participant->id}}" />


### PR DESCRIPTION
The 'anonymize participant' forms throw 419 page expired errors... probably because of this.